### PR TITLE
Hide TV Episode spoilers

### DIFF
--- a/1080i/Includes_Home_NetflixUI.xml
+++ b/1080i/Includes_Home_NetflixUI.xml
@@ -1563,6 +1563,20 @@
 		<value condition="Control.HasFocus(794)">$INFO[Container(794).ListItem.Rating]</value>
 	</variable>
 	<variable name="NetflixPlot">
+		<value condition="Control.HasFocus(777) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(777).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(778) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(778).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(779) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(779).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(780) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(780).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(781) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(781).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(782) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(782).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(783) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(783).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(784) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(784).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(785) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(785).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(786) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(786).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(787) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(787).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(788) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(788).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(789) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(789).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
+		<value condition="Control.HasFocus(790) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(790).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
 		<value condition="Control.HasFocus(777)">$INFO[Container(777).ListItem.Plot]</value>
 		<value condition="Control.HasFocus(778)">$INFO[Container(778).ListItem.Plot]</value>
 		<value condition="Control.HasFocus(779)">$INFO[Container(779).ListItem.Plot]</value>

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -42,7 +42,7 @@
     </variable>
     <variable name="FanartImage">
 		<value condition="Container.Content(episodes) + !Skin.HasSetting(osd.hidespoilers)">$INFO[ListItem.Icon]</value>
-		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">$INFO[ListItem.Art(fanart)]</value>
+		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">$INFO[ListItem.Art(tvshow.landscape)]</value>
 		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + ![stringcompare(ListItem.Overlay,OverlayUnWatched.png) + ListItem.IsResumable]">$INFO[ListItem.Icon]</value>
 		<value condition="!IsEmpty(ListItem.Art(fanart)) + !Container.Content(episodes)">$INFO[ListItem.Art(fanart)]</value>
         <value condition="!IsEmpty(ListItem.Thumb) + !Container.Content(episodes)">$INFO[ListItem.Thumb]</value>
@@ -50,7 +50,7 @@
     </variable>
      <variable name="LandscapeImage">
 		<value condition="Container.Content(episodes) + !Skin.HasSetting(osd.hidespoilers)">$INFO[ListItem.Icon]</value>
-		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">$INFO[ListItem.Art(fanart)]</value>
+		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">$INFO[ListItem.Art(tvshow.landscape)]</value>
 		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + ![stringcompare(ListItem.Overlay,OverlayUnWatched.png) + ListItem.IsResumable]">$INFO[ListItem.Icon]</value>
 		<value condition="!IsEmpty(ListItem.Art(landscape)) + !Container.Content(episodes)">$INFO[ListItem.Art(landscape)]</value> 
         <value condition="!IsEmpty(ListItem.Art(tvshow.landscape)) + !Container.Content(episodes)">$INFO[ListItem.Art(tvshow.landscape)]</value> 

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -41,16 +41,21 @@
         <value>$INFO[ListItem.Icon]</value>
     </variable>
     <variable name="FanartImage">
-        <value condition="!IsEmpty(ListItem.Art(fanart)) + !Container.Content(episodes)">$INFO[ListItem.Art(fanart)]</value>
-        <value condition="!IsEmpty(ListItem.Thumb)">$INFO[ListItem.Thumb]</value>
+		<value condition="Container.Content(episodes) + !Skin.HasSetting(osd.hidespoilers)">$INFO[ListItem.Icon]</value>
+		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">$INFO[ListItem.Art(fanart)]</value>
+		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + ![stringcompare(ListItem.Overlay,OverlayUnWatched.png) + ListItem.IsResumable]">$INFO[ListItem.Icon]</value>
+		<value condition="!IsEmpty(ListItem.Art(fanart)) + !Container.Content(episodes)">$INFO[ListItem.Art(fanart)]</value>
+        <value condition="!IsEmpty(ListItem.Thumb) + !Container.Content(episodes)">$INFO[ListItem.Thumb]</value>
         <value>$INFO[ListItem.Icon]</value>
     </variable>
      <variable name="LandscapeImage">
-        <value condition="!IsEmpty(ListItem.Art(landscape)) + !Container.Content(episodes)">$INFO[ListItem.Art(landscape)]</value> 
+		<value condition="Container.Content(episodes) + !Skin.HasSetting(osd.hidespoilers)">$INFO[ListItem.Icon]</value>
+		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">$INFO[ListItem.Art(fanart)]</value>
+		<value condition="Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + ![stringcompare(ListItem.Overlay,OverlayUnWatched.png) + ListItem.IsResumable]">$INFO[ListItem.Icon]</value>
+		<value condition="!IsEmpty(ListItem.Art(landscape)) + !Container.Content(episodes)">$INFO[ListItem.Art(landscape)]</value> 
         <value condition="!IsEmpty(ListItem.Art(tvshow.landscape)) + !Container.Content(episodes)">$INFO[ListItem.Art(tvshow.landscape)]</value> 
-        
         <value condition="!IsEmpty(ListItem.Art(fanart)) + !Container.Content(episodes)">$INFO[ListItem.Art(fanart)]</value>
-        <value condition="!IsEmpty(ListItem.Thumb)">$INFO[ListItem.Thumb]</value>
+        <value condition="!IsEmpty(ListItem.Thumb) + !Container.Content(episodes)">$INFO[ListItem.Thumb]</value>
         <value>$INFO[ListItem.Icon]</value>
     </variable>
     <variable name="MusicImage">

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -158,6 +158,7 @@
 		<value condition="StringCompare(Container(300).ListItem.Property(widget),NextAired)">$INFO[Container(301).ListItem.Label2,,[CR]]$INFO[Container(301).ListItem.Property(Plot)]</value>
 		<value condition="substring(Container(300).ListItem.Property(widget),Album)">$INFO[Container(301).ListItem.Property(Album_Description)]</value>
 		<value condition="StringCompare(Container(300).ListItem.Property(widget),Weather)">$INFO[Weather.Conditions]</value>
+		<value condition="!IsEmpty(Container(301).ListItem.Plot) + Skin.HasSetting(osd.hidespoilers) + !IsEmpty(Container(301).ListItem.TvShowTitle)">* Hidden to prevent spoilers *</value>
 		<value condition="!IsEmpty(Container(301).ListItem.Plot)">$INFO[Container(301).ListItem.Plot]</value>
 		<value condition="!IsEmpty(Container(301).ListItem.Property(Addon.Description))">$INFO[Container(301).ListItem.Property(Addon.Description)]</value>
 		<value>$LOCALIZE[19055]</value>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -45,7 +45,20 @@
 		<value condition="!IsEmpty(ListItem.Property(Album_Description))">$INFO[ListItem.Property(Album_Description)]</value>
 		<value condition="!IsEmpty(ListItem.Property(Addon.Description))">$INFO[ListItem.Property(Addon.Description)]</value>
 		<value condition="Container.Content(songs)">$INFO[ListItem.Artist,[B],[/B][CR]]$INFO[ListItem.Album]$INFO[ListItem.Year, (,)]</value>
-		<value condition="Container.Content(episodes)">$INFO[ListItem.Title,[B],[/B][CR],]$INFO[ListItem.Plot]</value>
+		<value condition="Container.Content(episodes) + !Skin.HasSetting(osd.hidespoilers)">$INFO[ListItem.Title,[B],[/B][CR],]$INFO[ListItem.Plot]</value>
+		<value condition="!IsEmpty(ListItem.Plot) + Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">$INFO[ListItem.Title,[B],[/B][CR],]* Hidden to prevent spoilers *</value>
+		<value condition="!IsEmpty(ListItem.Plot) + Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + ![stringcompare(ListItem.Overlay,OverlayUnWatched.png) + ListItem.IsResumable]">$INFO[ListItem.Title,[B],[/B][CR],]$INFO[ListItem.Plot]</value>
+		<value>$INFO[ListItem.Plot]</value>
+	</variable>
+	<variable name="LabelPlotBoxLong">
+		<value condition="!IsEmpty(Window(home).Property(Set.Movies.ExtendedPlot)) + [Container.Content(Sets) | substring(ListItem.Path,videodb://movies/sets,left)]">$INFO[Window(home).Property(Set.Movies.ExtendedPlot)]</value>
+		<value condition="!IsEmpty(ListItem.Property(Artist_Description))">$INFO[ListItem.Property(Artist_Description)]</value>
+		<value condition="!IsEmpty(ListItem.Property(Album_Description))">$INFO[ListItem.Property(Album_Description)]</value>
+		<value condition="!IsEmpty(ListItem.Property(Addon.Description))">$INFO[ListItem.Property(Addon.Description)]</value>
+		<value condition="Container.Content(songs)">$INFO[ListItem.Album]$INFO[ListItem.Year, (,)]</value>
+		<value condition="Container.Content(episodes) + !Skin.HasSetting(osd.hidespoilers)">$INFO[ListItem.Plot]</value>
+		<value condition="!IsEmpty(ListItem.Plot) + Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">* Hidden to prevent spoilers *</value>
+		<value condition="!IsEmpty(ListItem.Plot) + Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + ![stringcompare(ListItem.Overlay,OverlayUnWatched.png) + ListItem.IsResumable]">$INFO[ListItem.Plot]</value>
 		<value>$INFO[ListItem.Plot]</value>
 	</variable>
 	<variable name="LabelAudioChannels">
@@ -226,6 +239,7 @@
 		<value condition="!Skin.HasSetting(ColourHighlight)">Highlight</value>
 	</variable>
 	<variable name="Plot">
+		<value condition="[!IsEmpty(ListItem.PlotOutline) | !IsEmpty(ListItem.Plot)] + Skin.HasSetting(osd.hidespoilers) + Container.Content(episodes) + [stringcompare(ListItem.Overlay,OverlayUnWatched.png) | ListItem.IsResumable]">* Hidden to prevent spoilers *</value>
 		<value condition="!IsEmpty(ListItem.PlotOutline)">$INFO[ListItem.PlotOutline]</value>
 		<value condition="!IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
 	</variable>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -294,6 +294,14 @@
 						<onclick>Skin.ToggleSetting(osd.usetheme)</onclick>
 						<onclick>ReloadSkin()</onclick>
 					</control>
+					<control type="radiobutton" id="9240" description="Hide spoilers">
+						<width>1310</width>
+						<visible>ControlGroup(9100).HasFocus(9103)</visible>
+						<include>DefSettingsButton</include>
+						<label>Hide Spoilers for unwatched TV Shows</label>
+						<selected>Skin.HasSetting(osd.hidespoilers)</selected>
+						<onclick>Skin.ToggleSetting(osd.hidespoilers)</onclick>
+					</control>
 					<!-- Widgets -->
 					<control type="radiobutton" id="9241" description="Classic Widget">
 						<width>1310</width>

--- a/1080i/View_52_BigList.xml
+++ b/1080i/View_52_BigList.xml
@@ -82,7 +82,7 @@
             <width>100</width>
             <height>100</height>
             <aspectratio scalediffuse="false">scale</aspectratio>
-            <texture diffuse="common/circle.png" background="true">$INFO[ListItem.Icon]</texture>
+            <texture diffuse="common/circle.png" background="true">$VAR[FanartImage]</texture>
             <visible>!Skin.HasSetting(global.hidecirles)</visible>
         </control>
         <control type="image">
@@ -91,7 +91,7 @@
             <width>100</width>
             <height>100</height>
             <aspectratio scalediffuse="false">keep</aspectratio>
-            <texture background="true">$INFO[ListItem.Icon]</texture>
+            <texture background="true">$VAR[FanartImage]</texture>
             <visible>Skin.HasSetting(global.hidecirles)</visible>
         </control>
         <control type="label">
@@ -130,7 +130,7 @@
             <width>100</width>
             <height>100</height>
             <aspectratio scalediffuse="false">scale</aspectratio>
-            <texture diffuse="common/circle.png" background="true">$INFO[ListItem.Icon]</texture>
+            <texture diffuse="common/circle.png" background="true">$VAR[FanartImage]</texture>
             <visible>!Skin.HasSetting(global.hidecirles)</visible>
         </control>
         <control type="image">
@@ -139,7 +139,7 @@
             <width>100</width>
             <height>100</height>
             <aspectratio scalediffuse="false">keep</aspectratio>
-            <texture background="true">$INFO[ListItem.Icon]</texture>
+            <texture background="true">$VAR[FanartImage]</texture>
             <visible>Skin.HasSetting(global.hidecirles)</visible>
         </control>
         <control type="label">

--- a/1080i/View_54_Banner.xml
+++ b/1080i/View_54_Banner.xml
@@ -449,7 +449,7 @@
 								<bottom>54</bottom>
 								<align>justify</align>
 								<aligny>top</aligny>
-								<label>$INFO[ListItem.Plot]</label>
+							    <label>$VAR[LabelPlotBoxLong]</label>
 								<font>Tiny</font>
 								<textcolor>Light1</textcolor>
 								<selectedcolor>Light1</selectedcolor>

--- a/1080i/View_56_MediaInfo.xml
+++ b/1080i/View_56_MediaInfo.xml
@@ -106,7 +106,7 @@
                     </control>
                     <control type="textbox">
                         <font>Tiny</font>
-                        <label>$INFO[ListItem.Plot]</label>
+                        <label>$VAR[LabelPlotBoxLong]</label>
                         <textcolor>Dark2</textcolor>
                         <height>68</height>
                         <align>justify</align>

--- a/1080i/View_58_Cards.xml
+++ b/1080i/View_58_Cards.xml
@@ -131,7 +131,7 @@
                             <font>Tiny</font>
                             <textcolor>Dark1</textcolor>
                             <selectedcolor>Dark1</selectedcolor>
-                            <label>$INFO[ListItem.Plot]</label>
+							<label>$VAR[LabelPlotBoxLong]</label>
                         </control>
                         <control type="label">
                             <left>430</left>
@@ -253,7 +253,7 @@
                             <font>Tiny</font>
                             <textcolor>Light1</textcolor>
                             <selectedcolor>Light1</selectedcolor>
-                            <label>$INFO[ListItem.Plot]</label>
+							<label>$VAR[LabelPlotBoxLong]</label>
                         </control>
                         <control type="label">
                             <left>430</left>


### PR DESCRIPTION
With show unwatched plots activated in Kodi, activate hide spoilers in skin settings to hide plot & image previews of episode and still show movie plots.
